### PR TITLE
Update userparams_app_asterisk_service.conf

### DIFF
--- a/userparams_app_asterisk_service.conf
+++ b/userparams_app_asterisk_service.conf
@@ -17,7 +17,7 @@ UserParameter=asterisk.trunks_online,sudo -u zabbix sudo asterisk -rx "sip show 
 UserParameter=asterisk.trunks_offline,sudo -u zabbix sudo asterisk -rx "sip show registry" | grep -v "registrations" | grep -v "Reg.Time" | grep -v Registered | wc -l
 
 # number of active calls
-UserParameter=asterisk.active_calls,sudo -u zabbix sudo asterisk -rvvvvvx 'core show channels'| grep --text -i 'active call'| cut -c1
+UserParameter=asterisk.active_calls,sudo -u zabbix sudo asterisk -rvvvvvx 'core show channels'| grep --text -i 'active call'| cut -d ' ' -f1
 
 # number of seconds since last asterisk start
 UserParameter=asterisk.uptime,sudo -u zabbix sudo asterisk -rx "core show uptime seconds" | grep --text -i "System uptime:" | gawk '{print $3}'


### PR DESCRIPTION
bug fix: the asterisk.active_calls needs to get more than 1 caracter